### PR TITLE
Add module info via moditect

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,34 @@
 		</dependency>
 	</dependencies>
 	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.moditect</groupId>
+				<artifactId>moditect-maven-plugin</artifactId>
+				<version>1.0.0.Final</version>
+				<executions>
+					<execution>
+						<id>add-module-infos</id>
+						<phase>package</phase>
+						<goals>
+							<goal>add-module-info</goal>
+						</goals>
+						<configuration>
+							<jvmVersion>9</jvmVersion>
+							<overwriteExistingFiles>true</overwriteExistingFiles>
+							<module>
+								<moduleInfo>
+									<name>org.atteo.evo.inflector</name>
+									<exports>
+										org.atteo.evo.inflector;
+									</exports>
+								</moduleInfo>
+							</module>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
 		<pluginManagement>
 			<plugins>
 				<plugin>


### PR DESCRIPTION
This adds a module-info.class to the final JAR.

To Java versions less than 9 this will be ignored (it is under META-INF/versions/9 in the final jar) and for those using 9 or after will be able to use it.

This is part of a larger effort to try and fully modularize Spring so more people can use jlink without extra configuration.
